### PR TITLE
Make service with connect info

### DIFF
--- a/src/rest_grpc.rs
+++ b/src/rest_grpc.rs
@@ -1,11 +1,18 @@
-use axum::{Router, http::header::CONTENT_TYPE};
+use axum::{
+    extract::connect_info::{ConnectInfo, Connected}, 
+    http::header::CONTENT_TYPE, 
+    Router
+};
 use futures::ready;
 use hyper::{Request, Response};
 use std::{
     convert::Infallible,
     task::{Context, Poll},
+    any::Any,
+    net::SocketAddr,
 };
-use tower::{Service, make::Shared};
+use tonic::transport::server::TcpConnectInfo;
+use tower::{make::Shared, Service};
 
 /// This service splits all incoming requests either to the rest-service, or to
 /// the grpc-service based on the `content-type` header.
@@ -56,6 +63,161 @@ impl RestGrpcService {
     /// ```
     pub fn into_make_service(self) -> Shared<Self> {
         Shared::new(self)
+    }
+
+    /// Create a make-service with connect info from this service.
+    /// This allows you to extract connection information in your handlers using
+    /// `extract::ConnectInfo<C>`.
+    ///
+    /// Example:
+    ///
+    /// ```ignore
+    /// use axum_tonic::RestGrpcService;
+    /// use axum::extract::ConnectInfo;
+    /// use tokio::net::TcpListener;
+    /// use std::net::SocketAddr;
+    ///
+    /// // Create a router with a handler that uses connect info
+    /// let rest_router = axum::Router::new()
+    ///     .route("/", axum::routing::get(
+    ///         |ConnectInfo(addr): ConnectInfo<SocketAddr>| async move {
+    ///             format!("Hello from IP: {}", addr)
+    ///         }
+    ///     ));
+    ///
+    /// let grpc_router = // Your gRPC router
+    ///
+    /// let svc = RestGrpcService::new(rest_router, grpc_router);
+    ///
+    /// // Use with connect info
+    /// axum::serve(
+    ///     TcpListener::bind("127.0.0.1:3000").await.unwrap(),
+    ///     svc.into_make_service_with_connect_info::<SocketAddr>()
+    /// ).await.unwrap();
+    /// ```
+    pub fn into_make_service_with_connect_info<C>(self) -> RestGrpcMakeServiceWithConnectInfo<C> 
+    where
+        C: Send + Sync + Clone + 'static,
+    {
+        RestGrpcMakeServiceWithConnectInfo {
+            inner: self,
+            _connect_info: std::marker::PhantomData,
+        }
+    }
+}
+
+
+/// A wrapper service that captures connection info and passes it to the inner service.
+#[derive(Clone)]
+pub struct RestGrpcMakeServiceWithConnectInfo<C> {
+    inner: RestGrpcService,
+    _connect_info: std::marker::PhantomData<fn() -> C>,
+}
+
+impl<C, Target> Service<Target> for RestGrpcMakeServiceWithConnectInfo<C>
+where
+    C: Connected<Target> + Send + Sync + Clone + 'static,
+    Target: Send, // Target is typically &'a AddrStream, which is Send but not 'static
+{
+    type Response = RestGrpcServiceWithConnectInfo<C>;
+    type Error = Infallible;
+    type Future = std::future::Ready<Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, target: Target) -> Self::Future {
+        let connect_info = C::connect_info(target);
+        let inner = self.inner.clone();
+
+        std::future::ready(Ok(RestGrpcServiceWithConnectInfo {
+            inner,
+            connect_info,
+        }))
+    }
+}
+
+/// A service that holds both the RestGrpcService and the connection info.
+#[derive(Clone)]
+pub struct RestGrpcServiceWithConnectInfo<C> {
+    inner: RestGrpcService,
+    connect_info: C,
+}
+
+impl<C, ReqBody> Service<Request<ReqBody>> for RestGrpcServiceWithConnectInfo<C>
+where
+    C: Send + Sync + Clone + 'static,
+    ReqBody: http_body::Body<Data = axum::body::Bytes> + Send + 'static,
+    ReqBody::Error: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
+{
+    type Response = Response<axum::body::Body>;
+    type Error = Infallible;
+    type Future = <Router as Service<Request<ReqBody>>>::Future;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // drive readiness for each inner service and record which is ready
+        loop {
+            match (self.inner.rest_ready, self.inner.grpc_ready) {
+                (true, true) => {
+                    return Ok(()).into();
+                }
+                (false, _) => {
+                    ready!(
+                        <axum::Router as tower::Service<Request<ReqBody>>>::poll_ready(
+                            &mut self.inner.rest_router,
+                            cx
+                        )
+                    )?;
+                    self.inner.rest_ready = true;
+                }
+                (_, false) => {
+                    ready!(
+                        <axum::Router as tower::Service<Request<ReqBody>>>::poll_ready(
+                            &mut self.inner.rest_router,
+                            cx
+                        )
+                    )?;
+                    self.inner.grpc_ready = true;
+                }
+            }
+        }
+    }
+
+    fn call(&mut self, mut req: Request<ReqBody>) -> Self::Future {
+        // require users to call `poll_ready` first, if they don't we're allowed to panic
+        // as per the `tower::Service` contract
+        assert!(
+            self.inner.grpc_ready,
+            "grpc service not ready. Did you forget to call `poll_ready`?"
+        );
+        assert!(
+            self.inner.rest_ready,
+            "rest service not ready. Did you forget to call `poll_ready`?"
+        );
+
+        // Store connect info in request extensions for all requests passing through
+        // this service, so Axum handlers in both rest_router and grpc_router can access it.
+        req.extensions_mut().insert(ConnectInfo(self.connect_info.clone()));
+
+        // tonic via grpc_router should also have a TcpConnectInfo, this will populated
+        // `request.remote_addr()` but not `.local_addr()`.
+        if let Some(socket_addr) = (&self.connect_info as &dyn Any).downcast_ref::<SocketAddr>() {
+            req.extensions_mut().insert(TcpConnectInfo {
+                local_addr: None,
+                remote_addr: Some(*socket_addr),
+            });
+        }
+
+        // if we get a grpc request call the grpc service, otherwise call the rest service
+        // when calling a service it becomes not-ready so we have drive readiness again
+        if is_grpc_request(&req) {
+            self.inner.grpc_ready = false;
+            self.inner.grpc_router.call(req)
+        } else {
+            self.inner.rest_ready = false;
+            self.inner.rest_router.call(req)
+        }
     }
 }
 

--- a/tests/common/server.rs
+++ b/tests/common/server.rs
@@ -35,3 +35,40 @@ impl Test2 for Test2Service {
         Ok(Response::new(Test2Reply {}))
     }
 }
+
+pub struct Test1ServiceWithConnectInfo {
+    pub state: Mutex<u32>,
+    pub str: String,
+}
+
+#[async_trait]
+impl Test1 for Test1ServiceWithConnectInfo {
+    async fn test1(
+        &self,
+        request: tonic::Request<super::proto::Test1Request>,
+    ) -> Result<tonic::Response<super::proto::Test1Reply>, tonic::Status> {
+        *self.state.lock().unwrap() += 5;
+
+        println!("{}", self.state.lock().unwrap().clone());
+        if request.remote_addr().is_some() {
+            Ok(Response::new(Test1Reply {}))
+        } else {
+            Err(tonic::Status::internal("connect info error"))
+        }
+    }
+}
+
+pub struct Test2ServiceWithConnectInfo;
+#[async_trait]
+impl Test2 for Test2ServiceWithConnectInfo {
+    async fn test2(
+        &self,
+        request: tonic::Request<super::proto::Test2Request>,
+    ) -> Result<tonic::Response<super::proto::Test2Reply>, tonic::Status> {
+        if request.remote_addr().is_some() {
+            Ok(Response::new(Test2Reply {}))
+        } else {
+            Err(tonic::Status::internal("connect info error"))
+        }
+    }
+}

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -15,12 +15,11 @@ use common::{
         Test1Request, Test2Request, test1_client::Test1Client, test1_server::Test1Server,
         test2_client::Test2Client, test2_server::Test2Server,
     },
-    server::{Test1Service, Test2Service},
+    server::{Test1Service, Test1ServiceWithConnectInfo, Test2Service, Test2ServiceWithConnectInfo},
 };
 use tokio::net::TcpListener;
 use tonic::transport::Channel;
 
-use crate::common::server::{Test1ServiceWithConnectInfo, Test2ServiceWithConnectInfo};
 
 async fn do_nothing(req: Request, next: Next) -> Result<Response, GrpcStatus> {
     Ok(next.run(req).await)

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,6 +1,6 @@
 pub mod common;
 
-use std::{sync::Mutex, time::Duration};
+use std::{net::SocketAddr, sync::Mutex, time::Duration};
 
 use axum::{
     Router,
@@ -19,6 +19,8 @@ use common::{
 };
 use tokio::net::TcpListener;
 use tonic::transport::Channel;
+
+use crate::common::server::{Test1ServiceWithConnectInfo, Test2ServiceWithConnectInfo};
 
 async fn do_nothing(req: Request, next: Next) -> Result<Response, GrpcStatus> {
     Ok(next.run(req).await)
@@ -51,6 +53,59 @@ async fn main() {
         let rest_router = Router::new().merge(Router::new().route("/123", get(|| async move {})));
 
         let service = RestGrpcService::new(rest_router, grpc_router).into_make_service();
+
+        axum::serve(listener, service).await.unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let channel = Channel::from_static(address).connect().await.unwrap();
+
+    let mut client1 = Test1Client::new(channel.clone());
+    client1.test1(Test1Request {}).await.unwrap();
+    client1.test1(Test1Request {}).await.unwrap();
+    client1.test1(Test1Request {}).await.unwrap();
+    client1.test1(Test1Request {}).await.unwrap();
+    client1.test1(Test1Request {}).await.unwrap();
+
+    let channel = Channel::from_static(address).connect().await.unwrap();
+
+    client1.test1(Test1Request {}).await.unwrap();
+    client1.test1(Test1Request {}).await.unwrap();
+    client1.test1(Test1Request {}).await.unwrap();
+    client1.test1(Test1Request {}).await.unwrap();
+    client1.test1(Test1Request {}).await.unwrap();
+
+    let mut client2 = Test2Client::new(channel);
+    assert_eq!(
+        client2.test2(Test2Request {}).await.unwrap_err().code(),
+        tonic::Code::Cancelled,
+    );
+}
+
+#[tokio::test]
+async fn main_connect_info() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let address = Box::leak(Box::new(format!("http://127.0.0.1:{port}")));
+
+    tokio::task::spawn(async move {
+        let grpc_router1 = Router::new()
+            .nest_tonic(Test1Server::new(Test1ServiceWithConnectInfo {
+                state: Mutex::new(10),
+                str: String::new(),
+            }))
+            .layer(from_fn(do_nothing));
+
+        let grpc_router2 = Router::new()
+            .nest_tonic(Test2Server::new(Test2ServiceWithConnectInfo))
+            .layer(from_fn(cancel_request));
+
+        let grpc_router = grpc_router1.merge(grpc_router2);
+
+        let rest_router = Router::new().merge(Router::new().route("/123", get(|| async move {})));
+
+        let service = RestGrpcService::new(rest_router, grpc_router).into_make_service_with_connect_info::<SocketAddr>();
 
         axum::serve(listener, service).await.unwrap();
     });


### PR DESCRIPTION
This code adds the ability to use Axum like- [`.into_make_service_with_connect_info<C>()`](https://docs.rs/axum/latest/axum/extract/struct.ConnectInfo.html).
If used with `std::net::SocketAddr`, it will also populate tonic's `.remote_addr()` for use.

This is important for any code that depends on the remote address info being available (when it is not populated into an HTTP header via a proxy, load balancer, etc.)