### PR TITLE
prep-0.5 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 [package]
 edition = "2024"
 name = "axum_tonic"
-version = "0.4.1"
+version = "0.5.0"
 license = "MIT OR Apache-2.0"
 description = "Use Tonic with Axum"
 repository = "https://github.com/jvdwrf/axum-tonic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tonic-build = "0.14"
 tokio = { version = "1", features = ["full"] }
 prost = "0.14"
 tonic-prost = "0.14"
-tower-http = { version = "0.6", features = [
+tower-http = { version = "0.7", features = [
     "compression-gzip",
     "cors",
     "compression-br",

--- a/src/nest.rs
+++ b/src/nest.rs
@@ -23,7 +23,7 @@ pub trait NestTonic<B>: Sized {
             + NamedService,
         S::Future: Send + 'static + Unpin,
         B: Send + http_body::Body<Data = axum::body::Bytes> + 'static,
-        B::Error: Into<Box<(dyn std::error::Error + Send + Sync + 'static)>>;
+        B::Error: Into<Box<dyn std::error::Error + Send + Sync + 'static>>;
 }
 
 impl<B> NestTonic<B> for Router {
@@ -41,7 +41,7 @@ impl<B> NestTonic<B> for Router {
             + NamedService,
         S::Future: Send + 'static + Unpin,
         B: Send + http_body::Body<Data = axum::body::Bytes> + 'static,
-        B::Error: Into<Box<(dyn std::error::Error + Send + Sync + 'static)>>,
+        B::Error: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
     {
         // Nest it at /S::NAME, and wrap the service in an AxumTonicService
         self.route(
@@ -66,7 +66,7 @@ where
     S: Service<Request<B>, Error = Infallible, Response = hyper::Response<TBody>>,
     S::Future: Unpin,
     TBody: Send + http_body::Body<Data = axum::body::Bytes> + 'static,
-    TBody::Error: Into<Box<(dyn std::error::Error + Send + Sync + 'static)>>,
+    TBody::Error: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
 {
     type Response = axum::response::Response;
     type Error = Infallible;
@@ -99,7 +99,7 @@ impl<F, B> Future for AxumTonicServiceFut<F>
 where
     F: Future<Output = Result<hyper::Response<B>, Infallible>> + Unpin,
     B: Send + http_body::Body<Data = axum::body::Bytes> + 'static,
-    B::Error: Into<Box<(dyn std::error::Error + Send + Sync + 'static)>>,
+    B::Error: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
 {
     type Output = Result<axum::response::Response, Infallible>;
 

--- a/src/rest_grpc.rs
+++ b/src/rest_grpc.rs
@@ -1,18 +1,18 @@
 use axum::{
-    extract::connect_info::{ConnectInfo, Connected}, 
-    http::header::CONTENT_TYPE, 
-    Router
+    Router,
+    extract::connect_info::{ConnectInfo, Connected},
+    http::header::CONTENT_TYPE,
 };
 use futures::ready;
 use hyper::{Request, Response};
 use std::{
-    convert::Infallible,
-    task::{Context, Poll},
     any::Any,
+    convert::Infallible,
     net::SocketAddr,
+    task::{Context, Poll},
 };
 use tonic::transport::server::TcpConnectInfo;
-use tower::{make::Shared, Service};
+use tower::{Service, make::Shared};
 
 /// This service splits all incoming requests either to the rest-service, or to
 /// the grpc-service based on the `content-type` header.
@@ -95,7 +95,7 @@ impl RestGrpcService {
     ///     svc.into_make_service_with_connect_info::<SocketAddr>()
     /// ).await.unwrap();
     /// ```
-    pub fn into_make_service_with_connect_info<C>(self) -> RestGrpcMakeServiceWithConnectInfo<C> 
+    pub fn into_make_service_with_connect_info<C>(self) -> RestGrpcMakeServiceWithConnectInfo<C>
     where
         C: Send + Sync + Clone + 'static,
     {
@@ -105,7 +105,6 @@ impl RestGrpcService {
         }
     }
 }
-
 
 /// A wrapper service that captures connection info and passes it to the inner service.
 #[derive(Clone)]
@@ -198,7 +197,8 @@ where
 
         // Store connect info in request extensions for all requests passing through
         // this service, so Axum handlers in both rest_router and grpc_router can access it.
-        req.extensions_mut().insert(ConnectInfo(self.connect_info.clone()));
+        req.extensions_mut()
+            .insert(ConnectInfo(self.connect_info.clone()));
 
         // tonic via grpc_router should also have a TcpConnectInfo, this will populated
         // `request.remote_addr()` but not `.local_addr()`.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -15,11 +15,12 @@ use common::{
         Test1Request, Test2Request, test1_client::Test1Client, test1_server::Test1Server,
         test2_client::Test2Client, test2_server::Test2Server,
     },
-    server::{Test1Service, Test1ServiceWithConnectInfo, Test2Service, Test2ServiceWithConnectInfo},
+    server::{
+        Test1Service, Test1ServiceWithConnectInfo, Test2Service, Test2ServiceWithConnectInfo,
+    },
 };
 use tokio::net::TcpListener;
 use tonic::transport::Channel;
-
 
 async fn do_nothing(req: Request, next: Next) -> Result<Response, GrpcStatus> {
     Ok(next.run(req).await)
@@ -104,7 +105,8 @@ async fn main_connect_info() {
 
         let rest_router = Router::new().merge(Router::new().route("/123", get(|| async move {})));
 
-        let service = RestGrpcService::new(rest_router, grpc_router).into_make_service_with_connect_info::<SocketAddr>();
+        let service = RestGrpcService::new(rest_router, grpc_router)
+            .into_make_service_with_connect_info::<SocketAddr>();
 
         axum::serve(listener, service).await.unwrap();
     });


### PR DESCRIPTION
Reference Issue #15 

- update `Cargo.toml` version to 0.5.0
- remove build warnings (rustc 1.98.0)
- `cargo fmt` - automated code format clean ups,  mostly in `rest_grpc.rs` and `tests/lib.rs` such as removing extra spaces, breaking long lines, and reordering `use ...`.
- `cargo clippy` is clean

All `cargo test` pass.

Also, a post-merge request to `cargo publish` or whatever your process is to publish this version.  Thanks!